### PR TITLE
Update decomposition.pxi

### DIFF
--- a/src/pygcgopt/decomposition.pxi
+++ b/src/pygcgopt/decomposition.pxi
@@ -1430,7 +1430,7 @@ cdef class PartialDecomposition:
         return self._visualizations[format]
 
     def __repr__(self):
-        return f"<PartialDecomposition: nBlocks={self.getNBlocks()}, nMasterConss={self.getNMasterconss()}, nMasterVars={self.getNMastervars()}, nLinkingVars={self.getNLinkingvars()}, maxForWhiteScore={self.maxForWhiteScore}>"
+        return f"<PartialDecomposition: nBlocks={self.getNBlocks()}, nMasterConss={self.getNMasterconss()}, nMasterVars={self.getNMastervars()}, nLinkingVars={self.getNLinkingvars()}, max_for_white_score={self.max_for_white_score()}>"
 
 
 


### PR DESCRIPTION
This fixes the __repr__ of the decomposition file to use max_for_white_score() instead of outdated maxForWhiteScore(). The corresponding parameter is also updated to maxForWhiteScore. Resolves issue https://github.com/scipopt/PyGCGOpt/issues/38 and fixes `print(model.listDecompositions())`.