### PR TITLE
[Bugfix] build wheels for intel macs fetch the correct libscip zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: x86_64
           - os: macos-14
             arch: arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ if [[ $CIBW_ARCHS == *"arm"* ]]; then
     wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.7.0/libscip-macos-arm.zip -O scip.zip
     export MACOSX_DEPLOYMENT_TARGET=14.0
 else
-    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.7.0/libscip-macos.zip -O scip.zip
+    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.7.0/libscip-macos-intel.zip -O scip.zip
     export MACOSX_DEPLOYMENT_TARGET=13.0
 fi
 unzip scip.zip


### PR DESCRIPTION
The 0.4.1 release workflow (https://github.com/scipopt/PyGCGOpt/actions/runs/13265805396) failed, preventing the release to PyPi, which thus is still on 0.4.0.

The issue was, that the buildwheel for intel macs tried to fetch an non-existent URL https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.7.0/libscip-macos.zip

This PR fixes this issue, and afterwards 0.4.1 can be published to PyPi.

EDIT:
I have seen that the workflow also uses the image ubuntu 20.04, which is not supported anymore (https://github.com/actions/runner-images). I will add another commit to switch to 24.04